### PR TITLE
Added support for ToRunAboutEvery()

### DIFF
--- a/FluentScheduler.Tests/FluentScheduler.Tests.csproj
+++ b/FluentScheduler.Tests/FluentScheduler.Tests.csproj
@@ -42,10 +42,10 @@
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Should">
-      <HintPath>..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>
+      <HintPath>..\packages\Should.1.1.19\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="Should.Fluent">
-      <HintPath>..\packages\ShouldFluent.1.1.12.0\lib\Should.Fluent.dll</HintPath>
+      <HintPath>..\packages\ShouldFluent.1.1.19\lib\Should.Fluent.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FluentScheduler.Tests/ScheduleTests/DaysTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/DaysTests.cs
@@ -115,5 +115,13 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(15);
 			scheduledTime.Second.Should().Equal(0);
 		}
+
+        [Test]
+        public void SHould_Throw_Exception_When_Using_Randomized_Day_For_Start_Time()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            Assert.Throws(typeof(InvalidOperationException), delegate { schedule.ToRunAboutEvery(3).Days(); });
+        }
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/HoursTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/HoursTests.cs
@@ -136,5 +136,13 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(15);
 			scheduledTime.Second.Should().Equal(0);
 		}
+
+        [Test]
+        public void SHould_Throw_Exception_When_Using_Randomized_Hour_For_Start_Time()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            Assert.Throws(typeof(InvalidOperationException), delegate { schedule.ToRunAboutEvery(3).Hours(); });
+        }
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/MinutesTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/MinutesTests.cs
@@ -24,5 +24,20 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(30);
 			scheduledTime.Second.Should().Equal(input.Second);
 		}
+
+        [Test]
+        public void Should_Add_Specified_Minutes_To_Next_Run_Date_Random()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            schedule.ToRunAboutEvery(30).Minutes();
+
+            var input = new DateTime(2000,1,1);
+            var scheduledTime = schedule.CalculateNextRun(input);
+            scheduledTime.Date.Should().Equal(input.Date);
+
+            scheduledTime.Hour.Should().Equal(input.Hour);
+            scheduledTime.Minute.Should().Be.InRange(27, 30);
+        }
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/MonthsTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/MonthsTests.cs
@@ -36,5 +36,14 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(0);
 			scheduledTime.Second.Should().Equal(0);
 		}
+
+        [Test]
+        public void SHould_Throw_Exception_When_Using_Randomized_Month_For_Start_Time()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            Assert.Throws(typeof(InvalidOperationException), delegate { schedule.ToRunAboutEvery(1).Months(); });
+        }
+
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/SecondsTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/SecondsTests.cs
@@ -24,5 +24,22 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(input.Minute);
 			scheduledTime.Second.Should().Equal(30);
 		}
+
+        [Test]
+        public void Should_Add_Specified_Seconds_To_Next_Run_Date_Random()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            schedule.ToRunAboutEvery(300).Seconds();
+
+            var input = new DateTime(2000, 1, 1);
+            var scheduledTime = schedule.CalculateNextRun(input);
+            scheduledTime.Date.Should().Equal(input.Date);
+
+            scheduledTime.Hour.Should().Equal(input.Hour);
+            //we can only really test the minutes here because the seconds
+            // could end up at any value due to the randomness.
+            scheduledTime.Minute.Should().Be.InRange(4, 5);
+        }
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/WeeksTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/WeeksTests.cs
@@ -259,5 +259,13 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(15);
 			scheduledTime.Second.Should().Equal(0);			
 		}
+
+        [Test]
+        public void SHould_Throw_Exception_When_Using_Randomized_Week_For_Start_Time()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            Assert.Throws(typeof(InvalidOperationException), delegate { schedule.ToRunAboutEvery(1).Weeks(); });
+        }
 	}
 }

--- a/FluentScheduler.Tests/ScheduleTests/YearsTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/YearsTests.cs
@@ -36,5 +36,14 @@ namespace FluentScheduler.Tests.ScheduleTests
 			scheduledTime.Minute.Should().Equal(0);
 			scheduledTime.Second.Should().Equal(0);
 		}
+
+        [Test]
+        public void SHould_Throw_Exception_When_Using_Randomized_Year_For_Start_Time()
+        {
+            var task = new Mock<ITask>();
+            var schedule = new Schedule(task.Object);
+            Assert.Throws(typeof(InvalidOperationException), delegate { schedule.ToRunAboutEvery(2).Years(); });
+        }
+
 	}
 }

--- a/FluentScheduler.Tests/packages.config
+++ b/FluentScheduler.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
-  <package id="Should" version="1.1.12.0" />
-  <package id="ShouldFluent" version="1.1.12.0" />
+  <package id="Should" version="1.1.19" targetFramework="net40" />
+  <package id="ShouldFluent" version="1.1.19" targetFramework="net40" />
 </packages>

--- a/FluentScheduler/Model/Schedule.cs
+++ b/FluentScheduler/Model/Schedule.cs
@@ -64,6 +64,32 @@ namespace FluentScheduler.Model
 			return new TimeUnit(this, interval);
 		}
 
+        /// <summary>
+        /// Schedules the specified task to run for the specified interval.
+        /// The specified interval is randomized between a value of (interval - 10%) 
+        /// and (interval + 10%) to allow for the start time of the task to be 
+        /// different for each scheduled run.
+        /// <para></para>
+        /// <para>*** NOTE ***</para>
+        /// <para>The randomization only applies when using Seconds() and Minutes().
+        /// The other time ranges (hours, days, weeks, months, years) allow for an 
+        /// overridden "At()" that contradicts the intended randomness therefore, 
+        /// an InvalidOperationException will be thrown.
+        /// </para>
+        /// </summary>
+        /// <param name="interval"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">
+        /// If you use the <see cref="ToRunAboutEvery"/> method to schedule a 
+        /// random start time of the task, but use any method other than Seconds() or
+        /// Minutes() to specify the amount of time you want to use when scheduling
+        /// the next run time of the task.
+        /// </exception>
+        public TimeUnit ToRunAboutEvery(int interval)
+        {
+            return new TimeUnit(this, interval, true);
+        }
+
 		/// <summary>
 		/// Schedules the specified task to run once at the hour and minute specified.  If the hour and minute have passed, the task will be executed immediately.
 		/// </summary>

--- a/FluentScheduler/Model/SpecificRunTime.cs
+++ b/FluentScheduler/Model/SpecificRunTime.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FluentScheduler.Model
+﻿namespace FluentScheduler.Model
 {
 	public class SpecificRunTime
 	{
@@ -18,18 +16,48 @@ namespace FluentScheduler.Model
 		/// <returns></returns>
 		public TimeUnit AndEvery(int interval)
 		{
-			var parent = Schedule.Parent ?? Schedule;
-
-			var child = new Schedule(Schedule.Task)
-							{
-								Parent = parent,
-								Reentrant = parent.Reentrant,
-								Name = parent.Name
-							};
-
-			child.Parent.AdditionalSchedules.Add(child);
-
-			return child.ToRunEvery(interval);
+			return SetupChildSchedule().ToRunEvery(interval);
 		}
+
+        /// <summary>
+        /// Schedules the specified task to run for the specified interval.
+        /// The specified interval is randomized between a value of (interval - 10%) 
+        /// and (interval + 10%) to allow for the start time of the task to be 
+        /// different for each scheduled run.
+        /// <para></para>
+        /// <para>*** NOTE ***</para>
+        /// <para>The randomization only applies when using Seconds() and Minutes().
+        /// The other time ranges (hours, days, weeks, months, years) allow for an 
+        /// overridden "At()" that contradicts the intended randomness therefore, 
+        /// an InvalidOperationException will be thrown.
+        /// </para>
+        /// </summary>
+        /// <param name="interval"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">
+        /// If you use the <see cref="ToRunAboutEvery"/> method to schedule a 
+        /// random start time of the task, but use any method other than Seconds() or
+        /// Minutes() to specify the amount of time you want to use when scheduling
+        /// the next run time of the task.
+        /// </exception>
+        public TimeUnit AndAboutEvery(int interval)
+        {
+            return SetupChildSchedule().ToRunAboutEvery(interval);
+        }
+
+        private Schedule SetupChildSchedule()
+        {
+            var parent = Schedule.Parent ?? Schedule;
+            var child = new Schedule(Schedule.Task)
+            {
+                Parent = parent,
+                Reentrant = parent.Reentrant,
+                Name = parent.Name
+            };
+
+            child.Parent.AdditionalSchedules.Add(child);
+
+            return child;
+        }
 	}
 }

--- a/FluentScheduler/Model/TimeUnit.cs
+++ b/FluentScheduler/Model/TimeUnit.cs
@@ -2,44 +2,106 @@
 
 namespace FluentScheduler.Model
 {
-	public class TimeUnit
-	{
-		internal Schedule Schedule { get; private set; }
-		internal int Duration { get; private set; }
+    public class TimeUnit
+    {
+        private readonly Schedule _schedule;
+        private readonly int _duration;
+        private readonly bool _randomizeStartTime;
 
-		public TimeUnit(Schedule schedule, int duration)
-		{
-			Schedule = schedule;
-			Duration = duration;
-		}
+        public TimeUnit(Schedule schedule, int duration)
+        {
+            _schedule = schedule;
+            _duration = duration;
+        }
 
-		public void Seconds()
-		{
-			Schedule.CalculateNextRun = x => x.AddSeconds(Duration);
-		}
-		public void Minutes()
-		{
-			Schedule.CalculateNextRun = x => x.AddMinutes(Duration);
-		}
-		public HourUnit Hours()
-		{
-			return new HourUnit(Schedule, Duration);
-		}
-		public DayUnit Days()
-		{
-			return new DayUnit(Schedule, Duration);
-		}
-		public WeekUnit Weeks()
-		{
-			return new WeekUnit(Schedule, Duration);
-		}
-		public MonthUnit Months()
-		{
-			return new MonthUnit(Schedule, Duration);
-		}
-		public YearUnit Years()
-		{
-			return new YearUnit(Schedule, Duration);
-		}
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeUnit"/> class.
+        /// </summary>
+        /// <param name="schedule">The task scheduler</param>
+        /// <param name="duration">The duration between task runs</param>
+        /// <param name="randomizeStartTime">Whether to schedule the start time of the task at a 
+        /// random time based on the duration (+/- 10% of the duration)</param>
+        public TimeUnit(Schedule schedule, int duration, bool randomizeStartTime)
+        {
+            _schedule = schedule;
+            _duration = duration;
+            _randomizeStartTime = randomizeStartTime;
+        }
+
+        public void Seconds()
+        {
+            _schedule.CalculateNextRun = x => x.AddSeconds(_randomizeStartTime ? GetRandomDuration(_duration) : _duration);
+        }
+
+        public void Minutes()
+        {
+            _schedule.CalculateNextRun = x => x.AddMinutes(_randomizeStartTime ? GetRandomDuration(_duration) : _duration);
+        }
+
+        public HourUnit Hours()
+        {
+            if (_randomizeStartTime)
+            {
+                throw new InvalidOperationException("Using a randomized start time to calculate the next task run time is not supported for the Hours duration.");
+            }
+            return new HourUnit(_schedule, _duration);
+        }
+
+        public DayUnit Days()
+        {
+            if (_randomizeStartTime)
+            {
+                throw new InvalidOperationException("Using a randomized start time to calculate the next task run time is not supported for the Days duration.");
+            }
+            return new DayUnit(_schedule, _duration);
+        }
+
+        public WeekUnit Weeks()
+        {
+            if (_randomizeStartTime)
+            {
+                throw new InvalidOperationException("Using a randomized start time to calculate the next task run time is not supported for the Weeks duration.");
+            }
+
+            return new WeekUnit(_schedule, _duration);
+        }
+
+        public MonthUnit Months()
+        {
+            if (_randomizeStartTime)
+            {
+                throw new InvalidOperationException("Using a randomized start time to calculate the next task run time is not supported for the Months duration.");
+            }
+
+            return new MonthUnit(_schedule, _duration);
+        }
+
+        public YearUnit Years()
+        {
+            if (_randomizeStartTime)
+            {
+                throw new InvalidOperationException("Using a randomized start time to calculate the next task run time is not supported for the Years duration.");
+            }
+
+            return new YearUnit(_schedule, _duration);
+        }
+
+        private double GetRandomDuration(int duration)
+        {
+            return RandomNumberGenerator.Get(duration - (duration * .1), duration + (duration * .1));
+        }
+
+        /// <summary>
+        /// Generate a random number between the minimum and maximum values provided
+        /// </summary>
+        private class RandomNumberGenerator
+        {
+            private static readonly Random rnd = new Random();
+
+            public static double Get(double min, double max)
+            {
+                return (rnd.NextDouble() * (max - min) + min);
+            }
+        }
+    }
 }


### PR DESCRIPTION
The general intent behind the ToRunAboutEvery() method is similar to ToRunEvery() ,but takes the duration and picks a random number between 10% less and 10% more than the duration.  I have background tasks that run in a web farm of {n} number of servers.  When the servers recycle the application pools around the same time, I want to spread the task's next run time out to a slightly less predictable time so that the tasks that perform work on a shared database don't all start at the same time to perform the same function on the shared resource.  

Since the TimeUnits other than seconds and minutes allow for an "At()", I disallowed the randomization of the start time on TimeUnits other than seconds and minutes.  The "At()" call would circumvent the randomization concept and potentially cause some other undesired behavior.
