### PR TITLE
Adds support for running multiple tasks in a single schedule

### DIFF
--- a/ConsoleTester/Program.cs
+++ b/ConsoleTester/Program.cs
@@ -55,28 +55,48 @@ namespace ConsoleTester
 		{
 			DefaultAllTasksAsNonReentrant();
 
-			Schedule(() =>
-			{
-				if (TaskManager.RunningSchedules.Any(x => x.Name == "Sleepy Task"))
-				{
-					Console.WriteLine("Skipped named task because sleepy task is running");
-					return;
-				}
-				Console.WriteLine();
-				Console.WriteLine("... named task output ...");
-				Console.WriteLine();
+            //Schedule(() =>
+            //{
+            //    if (TaskManager.RunningSchedules.Any(x => x.Name == "Sleepy Task"))
+            //    {
+            //        Console.WriteLine("Skipped named task because sleepy task is running");
+            //        return;
+            //    }
+            //    Console.WriteLine();
+            //    Console.WriteLine("... named task output ...");
+            //    Console.WriteLine();
 
 
-			}).WithName("named task").ToRunEvery(1).Years();
+            //}).WithName("named task").ToRunEvery(1).Years();
 
-			Schedule(() =>
-			{
-				Console.WriteLine("Before sleep - " + DateTime.Now);
-				Console.WriteLine("Running Tasks: " + TaskManager.RunningSchedules.Length);
-				Thread.Sleep(4000);
-				Console.WriteLine("After sleep - " + DateTime.Now);
+            //Schedule(() =>
+            //{
+            //    Console.WriteLine("Before sleep - " + DateTime.Now);
+            //    Console.WriteLine("Running Tasks: " + TaskManager.RunningSchedules.Length);
+            //    Thread.Sleep(4000);
+            //    Console.WriteLine("After sleep - " + DateTime.Now);
 
-			}).WithName("Sleepy Task").ToRunEvery(1).Months().On(10).At(5, 0);
+            //}).WithName("Sleepy Task").ToRunEvery(1).Months().On(10).At(5, 0);
+
+            Schedule(() =>
+            {
+                Console.WriteLine("First task will fire first!");
+                Console.WriteLine("Waiting four seconds...");
+                Thread.Sleep(4000);
+            }).AndThen(() =>
+            {
+                Console.WriteLine("Then the second task fires!");
+            }).WithName("Multitask").ToRunNow();
+
+            //Schedule(() =>
+            //{
+            //    Console.WriteLine("First task fires and then sleeps for four seconds...");
+            //    Thread.Sleep(4000);
+            //}).AndThen(() =>
+            //{
+            //    Console.WriteLine("Second task fires concurrently!");
+            //}).Concurrently().WithName("Concurrent Multitask").ToRunNow();
+
 		}
 	}
 

--- a/FluentScheduler.Tests/FluentScheduler.Tests.csproj
+++ b/FluentScheduler.Tests/FluentScheduler.Tests.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RegistryTests\DefaultAllTasksAsNonReentrantTests.cs" />
+    <Compile Include="ScheduleTests\AndThenTests.cs" />
     <Compile Include="ScheduleTests\MonthsOnTheFourthTests.cs" />
     <Compile Include="ScheduleTests\NonReentrantTests.cs" />
     <Compile Include="ScheduleTests\SpecificRunTimeTests.cs" />

--- a/FluentScheduler.Tests/RegistryTests/DefaultAllTasksAsNonReentrantTests.cs
+++ b/FluentScheduler.Tests/RegistryTests/DefaultAllTasksAsNonReentrantTests.cs
@@ -35,6 +35,7 @@ namespace FluentScheduler.Tests.RegistryTests
 				schedule.Reentrant.Should().Be.False();
 			}
 		}
+
 		private class RegistryWithFutureTasksConfigured : Registry
 		{
 			public RegistryWithFutureTasksConfigured()

--- a/FluentScheduler.Tests/ScheduleTests/AndThenTests.cs
+++ b/FluentScheduler.Tests/ScheduleTests/AndThenTests.cs
@@ -1,0 +1,47 @@
+using System;
+using FluentScheduler.Model;
+using Moq;
+using NUnit.Framework;
+using Should.Fluent;
+
+namespace FluentScheduler.Tests.ScheduleTests
+{
+    [TestFixture]
+    public class AndThenTests
+    {
+
+        [SetUp]
+        public void Setup()
+        {
+            TaskManager.RunInTestingMode();
+        }
+
+        [Test]
+        public void Should_Be_Able_To_Schedule_Multiple_ITasks()
+        {
+            var task_1 = new Mock<ITask>();
+            var task_2 = new Mock<ITask>();
+            task_1.Setup(m => m.Execute());
+            task_2.Setup(m => m.Execute());
+            Schedule schedule = new Schedule(task_1.Object).AndThen(task_2.Object);
+            schedule.Execute();
+
+            task_1.Verify(m => m.Execute(), Times.Once());
+            task_2.Verify(m => m.Execute(), Times.Once());
+        }
+
+        [Test]
+        public void Should_Be_Able_To_Schedule_Multiple_Simple_Methods()
+        {
+            var task_1 = new Mock<ITask>();
+            var task_2 = new Mock<ITask>();
+            task_1.Setup(m => m.Execute());
+            task_2.Setup(m => m.Execute());
+            Schedule schedule = new Schedule(() => task_1.Object.Execute()).AndThen(() => task_2.Object.Execute());
+            schedule.Execute();
+
+            task_1.Verify(m => m.Execute(), Times.Once());
+            task_2.Verify(m => m.Execute(), Times.Once());
+        }
+    }
+}

--- a/FluentScheduler/FluentScheduler.csproj
+++ b/FluentScheduler/FluentScheduler.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenericEventHandler.cs" />
+    <Compile Include="ITaskFactory.cs" />
     <Compile Include="Model\TaskEndScheduleInformation.cs" />
     <Compile Include="Model\TaskStartScheduleInformation.cs" />
     <Compile Include="Registry.cs" />

--- a/FluentScheduler/ITaskFactory.cs
+++ b/FluentScheduler/ITaskFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentScheduler
+{
+    public class ITaskFactory
+    {
+        public ITaskFactory(){ }
+
+        /// <summary>
+        /// Retrieves the task instance for the specified type
+        /// </summary>
+        /// <typeparam name="T">Type of task to create</typeparam>
+        public virtual ITask GetTaskInstance<T>() where T : ITask
+        {
+            return Activator.CreateInstance<T>();
+        }
+    }
+}

--- a/FluentScheduler/Model/Schedule.cs
+++ b/FluentScheduler/Model/Schedule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace FluentScheduler.Model
 {
@@ -8,14 +9,17 @@ namespace FluentScheduler.Model
 		public DateTime NextRunTime { get; set; }
 		public string Name { get; set; }
 
-		internal Action Task { get; private set; }
+        internal List<Action> Tasks { get; private set; }
+        internal ITaskFactory TaskFactory {get; private set;}
 
 		internal Func<DateTime, DateTime> CalculateNextRun { get; set; }
 
 		internal ICollection<Schedule> AdditionalSchedules { get; set; }
-		internal bool Reentrant { get; set; }
 		internal Schedule Parent { get; set; }
 		internal int TaskExecutions { get; set; }
+
+        internal bool Concurrent { get; set; }
+        internal bool Reentrant { get; set; }
 
 		/// <summary>
 		/// Schedules the specified task to run
@@ -23,19 +27,48 @@ namespace FluentScheduler.Model
 		/// <param name="task">Task to run</param>
 		public Schedule(ITask task) : this(task.Execute)
 		{
+            TaskFactory = new ITaskFactory();
 		}
 
-		/// <summary>
-		/// Schedules the specified task to run
-		/// </summary>
-		/// <param name="action">Task to run</param>
-		public Schedule(Action action)
-		{
-			Task = action;
-			AdditionalSchedules = new List<Schedule>();
-			TaskExecutions = -1;
-			Reentrant = true;
-		}
+        /// <summary>
+        /// Creates a specific schedule for a group of tasks
+        /// </summary>
+        /// <param name="factory">An instantiated ITaskFactory.</param>
+        /// <param name="action">A parameterless method to run.</param>
+        public Schedule(ITaskFactory factory, Action action)
+        {            
+            Tasks = new List<Action>();
+            TaskFactory = factory;
+            Tasks.Add(action);
+            AdditionalSchedules = new List<Schedule>();
+            TaskExecutions = -1;
+            Reentrant = true;
+        }
+        
+        /// <summary>
+        /// Schedules the specified task to run
+        /// </summary>
+        /// <param name="action">A parameterless method to run</param>
+        public Schedule(Action action)
+        {
+            Tasks = new List<Action>();
+            Tasks.Add(action);
+            AdditionalSchedules = new List<Schedule>();
+            TaskExecutions = -1;
+            Reentrant = true;
+        }
+
+        /// <summary>
+        /// Schedules the specified task to run
+        /// </summary>
+        /// <param name="action">A list of parameterless methods to run</param>
+        public Schedule(List<Action> actions)
+        {
+            Tasks = actions;
+            AdditionalSchedules = new List<Schedule>();
+            TaskExecutions = -1;
+            Reentrant = true;
+        }
 
 		/// <summary>
 		/// Start the task now, regardless of any scheduled start time.
@@ -45,8 +78,42 @@ namespace FluentScheduler.Model
 			TaskManager.StartTask(this);
 		}
 
+        /// <summary>
+        /// Schedules another task to be run with this schedule
+        /// </summary>
+        /// <param name="task">An ITask type.</param>
+        public Schedule AndThen<T>() where T : ITask
+        {
+            //If no task factory has been added to the schedule, use the default.
+            if (TaskFactory == null)
+                TaskFactory = new ITaskFactory();
+
+            Tasks.Add(() => TaskFactory.GetTaskInstance<T>().Execute());
+            return this;
+        }
+
+        /// <summary>
+        /// Schedules another task to be run with this schedule
+        /// </summary>
+        /// <param name="task">A parameterless function to be executed.</param>
+        public Schedule AndThen(Action action)
+        {
+            Tasks.Add(action);
+            return this;
+        }
+
+        /// <summary>
+        /// Schedules another task to be run with this schedule
+        /// </summary>
+        /// <param name="task">An instantiated ITask.</param>
+        public Schedule AndThen(ITask task)
+        {
+            Tasks.Add(() => task.Execute());
+            return this;
+        }
+
 		/// <summary>
-		/// Schedules the specified task to run now
+		/// Schedules the specified tasks to run now
 		/// </summary>
 		/// <returns></returns>
 		public SpecificRunTime ToRunNow()
@@ -55,7 +122,7 @@ namespace FluentScheduler.Model
 		}
 
 		/// <summary>
-		/// Schedules the specified task to run for the specified interval
+		/// Schedules the specified tasks to run for the specified interval
 		/// </summary>
 		/// <param name="interval"></param>
 		/// <returns></returns>
@@ -65,7 +132,7 @@ namespace FluentScheduler.Model
 		}
 
 		/// <summary>
-		/// Schedules the specified task to run once at the hour and minute specified.  If the hour and minute have passed, the task will be executed immediately.
+		/// Schedules the specified tasks to run once at the hour and minute specified.  If the hour and minute have passed, the tasks will be executed immediately.
 		/// </summary>
 		/// <param name="hours">0-23: Represents the hour of today</param>
 		/// <param name="minutes">0-59: Represents the minute to run the task</param>
@@ -76,7 +143,7 @@ namespace FluentScheduler.Model
 		}
 
 		/// <summary>
-		/// Schedules the specified task to run once at the time specified.  If the time has passed, the task will be executed immediately.
+		/// Schedules the specified tasks to run once at the time specified.  If the time has passed, the task will be executed immediately.
 		/// </summary>
 		/// <param name="time">Time to run the task</param>
 		/// <returns></returns>
@@ -100,7 +167,7 @@ namespace FluentScheduler.Model
 		}
 
 		/// <summary>
-		/// Will not start a new instance of the task if a previous schedule is still running
+		/// Will not start a new instance of the scheduler if a previous schedule is still running
 		/// </summary>
 		/// <returns></returns>
 		public Schedule NonReentrant()
@@ -108,5 +175,15 @@ namespace FluentScheduler.Model
 			Reentrant = false;
 			return this;
 		}
+
+        /// <summary>
+        /// Allows for running multiple tasks in a schedule concurrently.
+        /// </summary>
+        /// <returns></returns>
+        public Schedule Concurrently()
+        {
+            Concurrent = true;
+            return this;
+        }
 	}
 }

--- a/FluentScheduler/Model/SpecificRunTime.cs
+++ b/FluentScheduler/Model/SpecificRunTime.cs
@@ -20,7 +20,7 @@ namespace FluentScheduler.Model
 		{
 			var parent = Schedule.Parent ?? Schedule;
 
-			var child = new Schedule(Schedule.Task)
+			var child = new Schedule(Schedule.Tasks)
 							{
 								Parent = parent,
 								Reentrant = parent.Reentrant,

--- a/FluentScheduler/Registry.cs
+++ b/FluentScheduler/Registry.cs
@@ -22,6 +22,7 @@ namespace FluentScheduler
 
 		internal List<Schedule> Schedules { get; private set; }
 		internal bool AllTasksConfiguredAsNonReentrant { get; set; }
+        public ITaskFactory TaskFactory { get; set; }
 
 		public Registry()
 		{
@@ -47,7 +48,7 @@ namespace FluentScheduler
 		/// <returns></returns>
 		public Schedule Schedule<T>() where T : ITask
 		{
-			var schedule = new Schedule(() => GetTaskInstance<T>().Execute());
+            var schedule = new Schedule(TaskFactory, () => TaskFactory.GetTaskInstance<T>().Execute());
 			if (AllTasksConfiguredAsNonReentrant)
 			{
 				schedule.NonReentrant();
@@ -76,16 +77,6 @@ namespace FluentScheduler
 				Schedules.Add(schedule);
 			}
 			return schedule;
-		}
-
-		/// <summary>
-		/// Retrieves the task instance for the specified type
-		/// </summary>
-		/// <typeparam name="T">Type of task to create</typeparam>
-		/// <returns></returns>
-		public virtual ITask GetTaskInstance<T>() where T : ITask
-		{
-			return Activator.CreateInstance<T>();
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ public class MyRegistry : Registry
 			Thread.Sleep(1000);
 			Console.WriteLine("Complex Action Task Ends: " + DateTime.Now);
 		}).ToRunNow().AndEvery(1).Months().OnTheFirst(DayOfWeek.Monday).At(3, 0);
+		
+		//Schedule multiple tasks to be run in a single schedule
+		Schedule<MyTask>().AndThen<MyOtherTask>().ToRunNow().AndEvery(5).Minutes();
+		
+		//Schedule multiple tasks to be run in a single schedule concurrently
+		Schedule<MyTask>().AndThen<MyOtherTask>().Concurrently().ToRunNow();
 	}
 } 
 ```
@@ -45,23 +51,30 @@ protected void Application_Start()
 Using your Dependency Injection / Inversion of Control tool of choice
 ---------------------------------------------------------------------
 
-FluentScheduler makes it easy to use your IOC tool to create task instances. Simply override the GetTaskInstance<T>() method on your Registry class. An example incorporating StructureMap:
+FluentScheduler makes it easy to use your IOC tool to create task instances. Simply extend the ITaskFactory class and override the GetTaskInstance<T>() method. An example incorporating StructureMap:
 
 ```csharp
 using FluentScheduler;
 using StructureMap;
 
+public class StructureMapTaskFacotry : ITaskFactory
+{
+	public StructureMapTaskFactory () { }
+	
+	public override ITask GetTaskInstance<T>()
+	{
+		return ObjectFactory.Container.GetInstance<T>();
+	}
+}
+
 public class MyRegistry : Registry
 {
 	public MyRegistry()
 	{
+		TaskFactory = new StructureMapTaskFactory();
+	
 		// Schedule an ITask to run at an interval
 		Schedule<MyTask>().ToRunNow().AndEvery(2).Seconds();
-	}
-
-	public override ITask GetTaskInstance<T>()
-	{
-		return ObjectFactory.Container.GetInstance<T>();
 	}
 } 
 ```


### PR DESCRIPTION
The main idea behind this pull request is to allow for grouping of tasks into a single schedule. We have a few use cases in our application that require tasks to fire sequentially, especially when it involves manipulating persisted data. We still wanted to keep those functions as atomic as possible, so grouping them into one large instantiated implementation of ITask wasn't feasible. This pull request adds the capability for "chaining" tasks together when adding a Schedule to a Registry:

``` csharp
    public MyRegistry()
    {
        //Schedule multiple tasks to be run in a single schedule
        Schedule<MyTask>().AndThen<MyOtherTask>().ToRunNow().AndEvery(5).Minutes();
    }
```

I also added in a Concurrent() function to Schedule to indicate that multiple tasks in a schedule can be run in parallel rather than sequentially:

``` csharp
    public MyRegistry()
    {
        //Schedule multiple tasks to be run in a single schedule
        Schedule<MyTask>().AndThen<MyOtherTask>().Concurrently().ToRunNow().AndEvery(5).Minutes();
    }
```

It also works with simple and complex actions as well:

``` csharp
    public MyRegistry()
    {
        //Schedule multiple tasks to be run in a single schedule
        Schedule(() =>
            {
                Console.WriteLine("First task will fire first!");
                Console.WriteLine("Waiting four seconds...");
                Thread.Sleep(4000);
            }).AndThen(() =>
            {
                Console.WriteLine("Then the second task fires!");
            }).WithName("Multitask").ToRunNow();
    }
```

This required moving the ITask activator function out into its own class (which I named ITaskFactory, though that name could stand to be thought about for awhile more and probably revisited), which means this _is_ a breaking change, as it requires anyone using a dependency injector to add a new class that extends ITaskFactory and override the GetTaskInstance function there, rather than directly on their registry class. However, I think this is a logical choice that mirrors other similar applications. If there's a way to avoid adding that additional class, I'd be all ears.

I did add a function onto TaskManager to set it into testing mode, in which it adds a Task.Wait() to the main task function. This was in order to run some asserts that the Execute delegates are actually being called. I'm not so sure this is necessary, but I also didn't necessarily see the harm.

Not much in core functionality has changed beyond that - anything that was done before should be perfectly compatible with this pull request.
