### PR TITLE
Added Pause/Resume ability on schedule

### DIFF
--- a/ConsoleTester/Program.cs
+++ b/ConsoleTester/Program.cs
@@ -13,7 +13,7 @@ namespace ConsoleTester
 			Console.WriteLine("Which the test you'd like to run (enter the test number):");
 			Console.WriteLine("1. DelayFor");
 			Console.WriteLine("2. MiscTests (everything else)");
-			Console.WriteLine("3. Pause/Resume ");
+			Console.WriteLine("3. Enable/Disable ");
 
 			byte testNum;
 			if (byte.TryParse(Console.ReadLine(), out testNum))
@@ -28,7 +28,7 @@ namespace ConsoleTester
 						MiscTests();
 						break;
 					case 3: // Test of Pausing/Resuming
-						PauseResumeTest();
+						EnableDisableTest();
 						break;
 					default:
 						Console.WriteLine(string.Format("There's not test #{0}", testNum));
@@ -43,25 +43,25 @@ namespace ConsoleTester
 			Console.ReadKey();
 		}
 
-		static void PauseResumeTest()
+		static void EnableDisableTest()
 		{
-			Console.WriteLine("Testing Pause/Resume...");
+			Console.WriteLine("Testing Enable/Disable...");
 			TaskManager.AddTask(() => Console.WriteLine("Runner 1 " + DateTime.Now), x => x.WithName("Runner1").ToRunEvery(1).Seconds());
 			//TaskManager.AddTask(() => Console.WriteLine("Runner 2 " + DateTime.Now), x => x.WithName("Runner2").ToRunEvery(1).Seconds());  //Test that pause/resume did not affect other tasks
 			TaskManager.AddTask(() =>
 			{
-				Console.WriteLine("Pause: " + DateTime.Now);
-				TaskManager.GetSchedule("Runner1").Pause();
+				Console.WriteLine("Disable: " + DateTime.Now);
+				TaskManager.GetSchedule("Runner1").Disable();
 
-			}, x => x.WithName("Pauser").ToRunOnceIn(10).Seconds());
+			}, x => x.WithName("Disable").ToRunOnceIn(10).Seconds());
 
 
 			TaskManager.AddTask(() =>
 			{
-				Console.WriteLine("Resume: " + DateTime.Now);
-				TaskManager.GetSchedule("Runner1").Resume();
+				Console.WriteLine("Enable: " + DateTime.Now);
+				TaskManager.GetSchedule("Runner1").Enable();
 
-			}, x => x.WithName("Resumer").ToRunOnceIn(20).Seconds());
+			}, x => x.WithName("Enable").ToRunOnceIn(20).Seconds());
 		}
 
 		static void DelayForTest()

--- a/FluentScheduler/Model/Schedule.cs
+++ b/FluentScheduler/Model/Schedule.cs
@@ -8,7 +8,7 @@ namespace FluentScheduler.Model
 		public DateTime NextRunTime { get; set; }
 		public string Name { get; set; }
 
-		public bool Paused { get; private set; }
+		public bool Disabled { get; private set; }
 
 		internal List<Action> Tasks { get; private set; }
 
@@ -40,7 +40,7 @@ namespace FluentScheduler.Model
 		/// <param name="action">A parameterless method to run</param>
 		public Schedule(Action action)
 		{
-			Paused = false;
+			Disabled = false;
 			Tasks = new List<Action> { action };
 			AdditionalSchedules = new List<Schedule>();
 			TaskExecutions = -1;
@@ -53,7 +53,7 @@ namespace FluentScheduler.Model
 		/// <param name="actions">A list of parameterless methods to run</param>
 		public Schedule(List<Action> actions)
 		{
-			Paused = false;
+			Disabled = false;
 			Tasks = actions;
 			AdditionalSchedules = new List<Schedule>();
 			TaskExecutions = -1;
@@ -177,15 +177,15 @@ namespace FluentScheduler.Model
 			return this;
 		}
 
-		public void Pause()
+		public void Disable()
 		{
-			Paused = true;
+			Disabled = true;
 		}
 
 
-		public void Resume()
+		public void Enable()
 		{
-			Paused = false;
+			Disabled = false;
 		}
 	}
 }

--- a/FluentScheduler/TaskManager.cs
+++ b/FluentScheduler/TaskManager.cs
@@ -210,7 +210,7 @@ namespace FluentScheduler
 
 		internal static void StartTask(Schedule schedule)
 		{
-			if (schedule.Paused)
+			if (schedule.Disabled)
 				return;
 
 			if (!schedule.Reentrant)


### PR DESCRIPTION
In response to my own request https://github.com/jgeurts/FluentScheduler/issues/45

Added property Paused on schedule wich makes task skip execution on schedule
With methods Pause() and Resume()
resume enables execution again

The schedule will continue to run during this time

Probable uses on recurring tasks where you need to momentarily suspend execution
