### PR TITLE
Relocate RestrictableUnitExtensions into root namespace.

### DIFF
--- a/FluentScheduler/FluentScheduler.csproj
+++ b/FluentScheduler/FluentScheduler.csproj
@@ -46,7 +46,7 @@
     <Compile Include="Model\IDayRestrictableUnit.cs" />
     <Compile Include="Model\ITimeRestrictableUnit.cs" />
     <Compile Include="Model\MinuteUnit.cs" />
-    <Compile Include="Extensions\RestrictableUnitExtensions.cs" />
+    <Compile Include="RestrictableUnitExtensions.cs" />
     <Compile Include="Model\SecondUnit.cs" />
     <Compile Include="Model\TaskExceptionInformation.cs" />
     <Compile Include="Model\DelayTimeUnit.cs" />

--- a/FluentScheduler/RestrictableUnitExtensions.cs
+++ b/FluentScheduler/RestrictableUnitExtensions.cs
@@ -1,7 +1,8 @@
 using System;
 using FluentScheduler.Model;
+using FluentScheduler.Extensions;
 
-namespace FluentScheduler.Extensions
+namespace FluentScheduler
 {
   public static class RestrictableUnitExtensions
   {


### PR DESCRIPTION
Before you publish you might like to consider moving the RestrictableUnitExtensions I added into the root namespace as I've subsequently found having to add FluentScheduler.Extensions all the time is really irritating.