### PR TITLE
Fix non-reentrant with ToRunNow

### DIFF
--- a/Library/Schedule.cs
+++ b/Library/Schedule.cs
@@ -45,17 +45,22 @@
         /// <param name="action">Job to schedule.</param>
         public Schedule(Action action) : this(new[] { action }) { }
 
+        internal Schedule(List<Action> actions)
+        {
+            Disabled = false;
+            Jobs = actions;
+            AdditionalSchedules = new List<Schedule>();
+            PendingRunOnce = false;
+            Reentrant = true;
+        }
+
         /// <summary>
         /// Schedules a new job in the registry.
         /// </summary>
         /// <param name="actions">Jobs to schedule</param>
         public Schedule(IEnumerable<Action> actions)
+            : this(actions.ToList())
         {
-            Disabled = false;
-            Jobs = actions.ToList();
-            AdditionalSchedules = new List<Schedule>();
-            PendingRunOnce = false;
-            Reentrant = true;
         }
 
         /// <summary>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>FluentScheduler</id>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <authors>Jim Geurts &lt;jim@biacreations.com&gt;,Talles L &lt;talleslasmar@gmail.com&gt; &amp; further contributors</authors>
         <licenseUrl>https://opensource.org/licenses/BSD-3-Clause</licenseUrl>
         <projectUrl>https://github.com/fluentscheduler/FluentScheduler</projectUrl>


### PR DESCRIPTION
This is to fix non-reentrant working with ToRunNow and another schedule.  The comparison is done directly on the the List<> which simply compares if it's the identical instance (not comparing the contents of the list).  This will make sure that additional schedules are created with the exact same List<> instance.
