### PR TITLE
Option to initialize the scheduler without starting it

### DIFF
--- a/Library/JobManager.cs
+++ b/Library/JobManager.cs
@@ -169,18 +169,30 @@
 
         #region Start, stop & initialize
 
+		/// <summary>
+		/// Initializes the job manager with the jobs to run.
+		/// </summary>
+		/// <param name="registry">Registry of jobs to run</param>
+		/// <param name="start">If true, scheduler will be started</param>
+		public static void Initialize(Registry registry, bool start)
+		{
+			if (registry == null)
+				throw new ArgumentNullException("registry");
+
+			_useUtc = registry.UtcTime;
+			CalculateNextRun(registry.Schedules).ToList().ForEach(RunJob);
+
+			if (start)
+				ScheduleJobs();
+		}
+
         /// <summary>
         /// Initializes the job manager with the jobs to run and starts it.
         /// </summary>
         /// <param name="registry">Registry of jobs to run</param>
         public static void Initialize(Registry registry)
         {
-            if (registry == null)
-                throw new ArgumentNullException("registry");
-
-            _useUtc = registry.UtcTime;
-            CalculateNextRun(registry.Schedules).ToList().ForEach(RunJob);
-            ScheduleJobs();
+			Initialize(registry, true);
         }
 
         /// <summary>


### PR DESCRIPTION
For our specific case, we needed to option to initialize the scheduler, but not start it automatically. This PR does not break the normal usecase of Initialize(Registry).