### PR TITLE
Proposed change : Run on WeekDaysOnly also for Monthly unit

### DIFF
--- a/Library/Unit/MonthOnDayOfMonthUnit.cs
+++ b/Library/Unit/MonthOnDayOfMonthUnit.cs
@@ -1,9 +1,11 @@
 ﻿namespace FluentScheduler
 {
+    using System;
+
     /// <summary>
     /// Unit of time that represents a specific day of the month.
     /// </summary>
-    public sealed class MonthOnDayOfMonthUnit
+    public sealed class MonthOnDayOfMonthUnit : IDayRestrictableUnit
     {
         private readonly int _duration;
 
@@ -19,18 +21,26 @@
 
         internal Schedule Schedule { get; private set; }
 
+        Schedule IDayRestrictableUnit.Schedule { get { return this.Schedule; } }
+
+        public DateTime DayIncrement(DateTime increment)
+        {
+            return increment.AddDays(_duration);
+        }
+
         /// <summary>
         /// Runs the job at the given time of day.
         /// </summary>
         /// <param name="hours">The hours (0 through 23).</param>
         /// <param name="minutes">The minutes (0 through 59).</param>
-        public void At(int hours, int minutes)
+        public IDayRestrictableUnit At(int hours, int minutes)
         {
             Schedule.CalculateNextRun = x =>
             {
                 var nextRun = x.Date.First().AddDays(_dayOfMonth - 1).AddHours(hours).AddMinutes(minutes);
                 return x > nextRun ? x.Date.First().AddMonths(_duration).AddDays(_dayOfMonth - 1).AddHours(hours).AddMinutes(minutes) : nextRun;
             };
+            return this;
         }
     }
 }

--- a/UnitTests/ScheduleTests/MonthsWeekDaysOnlyTests.cs
+++ b/UnitTests/ScheduleTests/MonthsWeekDaysOnlyTests.cs
@@ -1,0 +1,86 @@
+﻿namespace FluentScheduler.Tests.UnitTests.ScheduleTests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using System;
+
+    [TestClass]
+    public class MonthsWeekDaysOnlyTests
+    {
+        [TestMethod]
+        public void Should_Pick_Monday_If_Now_Is_Saturday()
+        {
+            // Arrange
+            var input = new DateTime(2016, 10, 1, 2, 0, 0);
+            var expected = new DateTime(2016, 10, 3, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().On(1).At(3, 15).WeekdaysOnly();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DayOfWeek.Saturday, input.DayOfWeek);
+            Assert.AreEqual(DayOfWeek.Monday, actual.DayOfWeek);
+        }
+
+            
+        [TestMethod]
+        public void Should_Pick_Monday_If_Now_Is_Sunday()
+        {
+            // Arrange
+            var input = new DateTime(2016, 10, 2, 2, 0, 0);
+            var expected = new DateTime(2016, 10, 3, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().On(2).At(3, 15).WeekdaysOnly();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DayOfWeek.Sunday, input.DayOfWeek);
+            Assert.AreEqual(DayOfWeek.Monday, actual.DayOfWeek);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Today_If_Now_Is_Monday()
+        {
+            // Arrange
+            var input = new DateTime(2016, 8, 1, 2, 0, 0);
+            var expected = new DateTime(2016, 8, 1, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().On(1).At(3, 15).WeekdaysOnly();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DayOfWeek.Monday, input.DayOfWeek);
+            Assert.AreEqual(DayOfWeek.Monday, actual.DayOfWeek);
+            Assert.AreEqual(8, actual.Month);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Next_Month_If_Now_Is_Too_Late_On_Provided_Day()
+        {
+            // Arrange
+            var runHour = 3;
+            var input = new DateTime(2016, 8, 4, runHour+1, 15, 0);
+            var expected = new DateTime(2016, 9, 5, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().On(4).At(runHour, 15).WeekdaysOnly();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(DayOfWeek.Thursday, input.DayOfWeek);
+            Assert.AreEqual(DayOfWeek.Monday, actual.DayOfWeek);
+            Assert.AreEqual(9, actual.Month);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -100,6 +100,7 @@
     </Compile>
     <Compile Include="ScheduleTests\MonthsOnTheThirdTests.cs" />
     <Compile Include="ScheduleTests\MonthsTests.cs" />
+    <Compile Include="ScheduleTests\MonthsWeekDaysOnlyTests.cs" />
     <Compile Include="ScheduleTests\NonReentrantTests.cs" />
     <Compile Include="ScheduleTests\RemoveTests.cs" />
     <Compile Include="ScheduleTests\SecondsTests.cs" />


### PR DESCRIPTION
Hi, we ran on issues trying to run jobs on the fifth day of the month every month, but not during weekends (on weekends on corp servers are bombarded with product updates and unstable).

I added a possible fix to also use the .WeekDaysOnly() extension method for months.

Let me know if anything is odd, wrong or just plain unwanted.

Thanks !