### PR TITLE
Add Milliseconds Time Unit

### DIFF
--- a/Library/Extension/DelayForExtensions.cs
+++ b/Library/Extension/DelayForExtensions.cs
@@ -30,6 +30,19 @@
         /// </summary>
         /// <param name="unit">The schedule being affected.</param>
         /// <param name="interval">Interval to wait.</param>
+        public static DelayTimeUnit DelayFor(this MillisecondUnit unit, int interval)
+        {
+            if (unit == null)
+                throw new ArgumentNullException("unit");
+
+            return DelayFor(unit.Schedule, interval);
+        }
+
+        /// <summary>
+        /// Delays the job for the given interval.
+        /// </summary>
+        /// <param name="unit">The schedule being affected.</param>
+        /// <param name="interval">Interval to wait.</param>
         public static DelayTimeUnit DelayFor(this SecondUnit unit, int interval)
         {
             if (unit == null)

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Unit\ITimeRestrictableUnit.cs" />
     <Compile Include="Unit\MinuteUnit.cs" />
     <Compile Include="Extension\RestrictableUnitExtensions.cs" />
+    <Compile Include="Unit\MillisecondUnit.cs" />
     <Compile Include="Unit\SecondUnit.cs" />
     <Compile Include="Event\JobExceptionInfo.cs" />
     <Compile Include="Unit\DelayTimeUnit.cs" />

--- a/Library/Unit/DelayTimeUnit.cs
+++ b/Library/Unit/DelayTimeUnit.cs
@@ -19,6 +19,8 @@
 
         /// <summary>
         /// Sets the interval to milliseconds.
+        /// <para />
+        /// Note: Precision timing is not guaranteed.  Low intervals may result in high error.
         /// </summary>
         public void Milliseconds()
         {

--- a/Library/Unit/DelayTimeUnit.cs
+++ b/Library/Unit/DelayTimeUnit.cs
@@ -18,6 +18,14 @@
         internal Schedule Schedule { get; private set; }
 
         /// <summary>
+        /// Sets the interval to milliseconds.
+        /// </summary>
+        public void Milliseconds()
+        {
+            Schedule.DelayRunFor = TimeSpan.FromMilliseconds(_interval);
+        }
+
+        /// <summary>
         /// Sets the interval to seconds.
         /// </summary>
         public void Seconds()

--- a/Library/Unit/MillisecondUnit.cs
+++ b/Library/Unit/MillisecondUnit.cs
@@ -1,7 +1,7 @@
 ﻿namespace FluentScheduler
 {
     /// <summary>
-    /// Unit of time in seconds.
+    /// Unit of time in milliseconds.
     /// </summary>
     public sealed class MillisecondUnit : ITimeRestrictableUnit
     {

--- a/Library/Unit/MillisecondUnit.cs
+++ b/Library/Unit/MillisecondUnit.cs
@@ -1,0 +1,21 @@
+﻿namespace FluentScheduler
+{
+    /// <summary>
+    /// Unit of time in seconds.
+    /// </summary>
+    public sealed class MillisecondUnit : ITimeRestrictableUnit
+    {
+        private readonly int _duration;
+
+        internal MillisecondUnit(Schedule schedule, int duration)
+        {
+            _duration = duration;
+            Schedule = schedule;
+            Schedule.CalculateNextRun = x => x.AddMilliseconds(_duration);
+        }
+
+        internal Schedule Schedule { get; private set; }
+
+        Schedule ITimeRestrictableUnit.Schedule { get { return this.Schedule; } }
+    }
+}

--- a/Library/Unit/TimeUnit.cs
+++ b/Library/Unit/TimeUnit.cs
@@ -16,6 +16,16 @@
         }
 
         /// <summary>
+        /// Sets the interval to milliseconds.
+        /// <para />
+        /// Note: Precision timing is not guaranteed.  Low intervals may result in high error.
+        /// </summary>
+        public MillisecondUnit Milliseconds()
+        {
+            return new MillisecondUnit(_schedule, _duration);
+        }
+
+        /// <summary>
         /// Sets the interval to seconds.
         /// </summary>
         public SecondUnit Seconds()

--- a/PortableLibrary/PortableLibrary.csproj
+++ b/PortableLibrary/PortableLibrary.csproj
@@ -143,6 +143,7 @@
       <Link>Schedule.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Unit\MillisecondUnit.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PortableLibrary/Unit/MillisecondUnit.cs
+++ b/PortableLibrary/Unit/MillisecondUnit.cs
@@ -1,7 +1,7 @@
 ﻿namespace FluentScheduler
 {
     /// <summary>
-    /// Unit of time in seconds.
+    /// Unit of time in milliseconds.
     /// </summary>
     public sealed class MillisecondUnit : ITimeRestrictableUnit
     {

--- a/PortableLibrary/Unit/MillisecondUnit.cs
+++ b/PortableLibrary/Unit/MillisecondUnit.cs
@@ -1,0 +1,21 @@
+﻿namespace FluentScheduler
+{
+    /// <summary>
+    /// Unit of time in seconds.
+    /// </summary>
+    public sealed class MillisecondUnit : ITimeRestrictableUnit
+    {
+        private readonly int _duration;
+
+        internal MillisecondUnit(Schedule schedule, int duration)
+        {
+            _duration = duration;
+            Schedule = schedule;
+            Schedule.CalculateNextRun = x => x.AddMilliseconds(_duration);
+        }
+
+        internal Schedule Schedule { get; private set; }
+
+        Schedule ITimeRestrictableUnit.Schedule { get { return this.Schedule; } }
+    }
+}

--- a/TestApplication/MyRegistry.cs
+++ b/TestApplication/MyRegistry.cs
@@ -19,6 +19,7 @@
             Parameter();
             Disposable();
 
+            FiveHundredMilliseconds();
             FiveMinutes();
             TenMinutes();
             Hour();
@@ -101,6 +102,14 @@
         private void Disposable()
         {
             Schedule<DisposableJob>().WithName("[disposable").ToRunOnceIn(10).Seconds();
+        }
+
+        private void FiveHundredMilliseconds()
+        {
+            L.Register("[five hundred milliseconds]");
+
+            Schedule(() => L.Log("[five hundred milliseconds]", "Five hundred milliseconds have passed."))
+                .WithName("[five hundred milliseconds]").ToRunOnceAt(DateTime.Now.AddMilliseconds(500)).AndEvery(500).Milliseconds();
         }
 
         private void FiveMinutes()

--- a/UnitTests/ScheduleTests/DelayFor_ToRunEvery_Tests.cs
+++ b/UnitTests/ScheduleTests/DelayFor_ToRunEvery_Tests.cs
@@ -8,6 +8,25 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
     public class DelayFor_ToRunEvery_Tests
     {
         [TestMethod]
+        public void Should_Delay_ToRunEvery_For_500_Milliseconds()
+        {
+            // Arrange
+            var expected = DateTime.Now.AddMilliseconds(600);
+
+            // Act
+            JobManager.AddJob(
+                () => { },
+                s => s.WithName("run every 500 milliseconds and delay for 100 milliseconds")
+                    .ToRunEvery(500).Milliseconds()
+                    .DelayFor(100).Milliseconds()
+            );
+            var actual = JobManager.GetSchedule("run every 500 milliseconds and delay for 100 milliseconds").NextRun;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void Should_Delay_ToRunEvery_For_2_Seconds()
         {
             // Arrange

--- a/UnitTests/ScheduleTests/DelayFor_ToRunEvery_Tests.cs
+++ b/UnitTests/ScheduleTests/DelayFor_ToRunEvery_Tests.cs
@@ -23,7 +23,7 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
             var actual = JobManager.GetSchedule("run every 500 milliseconds and delay for 100 milliseconds").NextRun;
 
             // Assert
-            Assert.AreEqual(expected, actual);
+            Assert.IsTrue((expected - actual).TotalMilliseconds < 150);
         }
 
         [TestMethod]

--- a/UnitTests/ScheduleTests/DelayFor_ToRunNow_Tests.cs
+++ b/UnitTests/ScheduleTests/DelayFor_ToRunNow_Tests.cs
@@ -8,6 +8,26 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
     public class DelayFor_ToRunOnceAt_Tests
     {
         [TestMethod]
+        public void Should_Delay_ToRunOnceAt_For_500_Milliseconds()
+        {
+            // Arrange
+            var now = DateTime.Now;
+            var expected = now.AddMilliseconds(500);
+
+            // Act
+            JobManager.AddJob(
+                () => { },
+                s => s.WithName("run once at x and delay for 500 milliseconds")
+                    .ToRunOnceAt(now)
+                    .DelayFor(500).Milliseconds()
+            );
+            var actual = JobManager.GetSchedule("run once at x and delay for 500 milliseconds").NextRun;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void Should_Delay_ToRunOnceAt_For_2_Seconds()
         {
             // Arrange

--- a/UnitTests/ScheduleTests/DelayFor_ToRunOnceAt_Tests.cs
+++ b/UnitTests/ScheduleTests/DelayFor_ToRunOnceAt_Tests.cs
@@ -8,6 +8,24 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
     public class DelayFor_ToRunNow_Tests
     {
         [TestMethod]
+        public void Should_Delay_ToRunNow_For_500_Milliseconds()
+        {
+            // Arrange
+            var expected = DateTime.Now.AddMilliseconds(500);
+
+            // Act
+            JobManager.AddJob(
+                () => { },
+                x => x.WithName("run now and delay for 500 milliseconds")
+                    .ToRunNow().DelayFor(500).Milliseconds()
+            );
+            var actual = JobManager.GetSchedule("run now and delay for 500 milliseconds").NextRun;
+
+            // Assert
+            Assert.AreEqual(expected.WithoutMilliseconds(), actual.WithoutMilliseconds());
+        }
+
+        [TestMethod]
         public void Should_Delay_ToRunNow_For_2_Seconds()
         {
             // Arrange

--- a/UnitTests/ScheduleTests/DelayFor_ToRunOnceAt_Tests.cs
+++ b/UnitTests/ScheduleTests/DelayFor_ToRunOnceAt_Tests.cs
@@ -22,7 +22,7 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
             var actual = JobManager.GetSchedule("run now and delay for 500 milliseconds").NextRun;
 
             // Assert
-            Assert.AreEqual(expected.WithoutMilliseconds(), actual.WithoutMilliseconds());
+            Assert.AreEqual(expected, actual);
         }
 
         [TestMethod]

--- a/UnitTests/ScheduleTests/MillisecondsTests.cs
+++ b/UnitTests/ScheduleTests/MillisecondsTests.cs
@@ -1,0 +1,25 @@
+namespace FluentScheduler.Tests.UnitTests.ScheduleTests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    [TestClass]
+    public class MillisecondsTests
+    {
+        [TestMethod]
+        public void Should_Add_Specified_Milliseconds_To_Next_Run_Date()
+        {
+            // Assert
+            var input = new DateTime(2000, 1, 1);
+            var expected = new DateTime(2000, 1, 1, 0, 0, 0, 500);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(500).Milliseconds();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ScheduleTests\MonthsWeekDaysOnlyTests.cs" />
     <Compile Include="ScheduleTests\NonReentrantTests.cs" />
     <Compile Include="ScheduleTests\RemoveTests.cs" />
+    <Compile Include="ScheduleTests\MillisecondsTests.cs" />
     <Compile Include="ScheduleTests\SecondsTests.cs" />
     <Compile Include="ScheduleTests\SpecificRunTimeTests.cs" />
     <Compile Include="ScheduleTests\WeekDaysTests.cs" />


### PR DESCRIPTION
This pull request adds milliseconds as a time unit.   This is my first contribution to an open source repository ever so please go easy on me :D

I understand that FluentScheduler isn't meant to be a precision timing library, so to account for that I've done a couple things:
Added a note on .Milliseconds() to tell the consumer that precision timing isn't guaranteed.
Allowed 150 milliseconds of error in the unit test for milliseconds.

In practice, the amount of error is between 1-15 milliseconds.  I tested with over 5000 jobs and the library never had more than 50 milliseconds of error.

I'm super open to any feedback!  Thanks for letting me help.