### PR TITLE
Correct ASP.NET example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,22 @@ public class SampleJob : IJob, IRegisteredObject
 
     public void Execute()
     {
-        lock (_lock)
+        try
         {
-            if (_shuttingDown)
-                return;
+            lock (_lock)
+            {
+                if (_shuttingDown)
+                {
+                    return;
+                }
 
-            // Do work, son!
+                // Do work, son!
+            }
+        }
+        finally
+        {
+            // Always unregister the job when done.
+            HostingEnvironment.UnregisterObject(this);
         }
     }
 


### PR DESCRIPTION
If HostingEnvironment.UnregisterObject(this) is not called at the end of the Execute() method IIS will keep a reference of the Job and so it will not be garbage collected. This can be reproduced by putting a breakpoint in the Stop(bool) method and stopping IIS (Express). The breakpoint will hit for every job that was executed.