### PR TITLE
Added LastWeekdayBefore and FirstWeekdayAfter

### DIFF
--- a/FluentScheduler.UnitTests/Fluent/3 - Duration/Month/MonthUnitTests.cs
+++ b/FluentScheduler.UnitTests/Fluent/3 - Duration/Month/MonthUnitTests.cs
@@ -104,5 +104,89 @@
             Assert.AreEqual(DayOfWeek.Friday, calculated.Value.DayOfWeek);
             Assert.AreEqual(expectedDate, calculated.Value.Date);
         }
+
+        [TestMethod]
+        public void LastWeekdayBefore()
+        {
+            // Arrange
+            var fluentCalculator = new FluentTimeCalculator();
+            var calculator = (ITimeCalculator)fluentCalculator;
+            var run = new RunSpecifier(fluentCalculator);
+
+            var now = new DateTime(2018, 10, 20);
+            var expectedDate = new DateTime(2018, 10, 18);
+            var dayOfWeek = DayOfWeek.Thursday;
+
+            // Act
+            run.Every(0).Months().LastWeekdayBefore(dayOfWeek, 20);
+            var calculated = calculator.Calculate(now);
+
+            // Assert
+            Assert.AreEqual(dayOfWeek, calculated.Value.DayOfWeek);
+            Assert.AreEqual(expectedDate, calculated.Value.Date);
+        }
+
+        [TestMethod]
+        public void LastWeekdayBeforeAt()
+        {
+            // Arrange
+            var fluentCalculator = new FluentTimeCalculator();
+            var calculator = (ITimeCalculator)fluentCalculator;
+            var run = new RunSpecifier(fluentCalculator);
+
+            var now = new DateTime(2018, 10, 20);
+            var expectedDate = new DateTime(2018, 10, 18, 9, 15, 0);
+            var dayOfWeek = DayOfWeek.Thursday;
+
+            // Act
+            run.Every(0).Months().LastWeekdayBefore(dayOfWeek, 20).At(9, 15);
+            var calculated = calculator.Calculate(now);
+
+            // Assert
+            Assert.AreEqual(dayOfWeek, calculated.Value.DayOfWeek);
+            Assert.AreEqual(expectedDate, calculated.Value);
+        }
+
+        [TestMethod]
+        public void FirstWeekdayAfter()
+        {
+            // Arrange
+            var fluentCalculator = new FluentTimeCalculator();
+            var calculator = (ITimeCalculator)fluentCalculator;
+            var run = new RunSpecifier(fluentCalculator);
+
+            var now = new DateTime(2018, 10, 20);
+            var expectedDate = new DateTime(2018, 10, 25);
+            var dayOfWeek = DayOfWeek.Thursday;
+
+            // Act
+            run.Every(0).Months().FirstWeekdayAfter(dayOfWeek, 20);
+            var calculated = calculator.Calculate(now);
+
+            // Assert
+            Assert.AreEqual(dayOfWeek, calculated.Value.DayOfWeek);
+            Assert.AreEqual(expectedDate, calculated.Value.Date);
+        }
+
+        [TestMethod]
+        public void FirstWeekdayAfterAt()
+        {
+            // Arrange
+            var fluentCalculator = new FluentTimeCalculator();
+            var calculator = (ITimeCalculator)fluentCalculator;
+            var run = new RunSpecifier(fluentCalculator);
+
+            var now = new DateTime(2018, 10, 20);
+            var expectedDate = new DateTime(2018, 10, 25, 9, 15, 0);
+            var dayOfWeek = DayOfWeek.Thursday;
+
+            // Act
+            run.Every(0).Months().FirstWeekdayAfter(dayOfWeek, 20).At(9, 15);
+            var calculated = calculator.Calculate(now);
+
+            // Assert
+            Assert.AreEqual(dayOfWeek, calculated.Value.DayOfWeek);
+            Assert.AreEqual(expectedDate, calculated.Value);
+        }
     }
 }

--- a/FluentScheduler/Fluent/3 - Duration/Month/MonthUnit.cs
+++ b/FluentScheduler/Fluent/3 - Duration/Month/MonthUnit.cs
@@ -61,6 +61,50 @@
             return new PeriodOnceSet(_calculator);
         }
 
+        /// <summary>
+        /// Runs the job on the last given week of day before the given day of month.
+        /// </summary>
+        /// <param name="dayOfWeek">The day of the week</param>
+        /// <param name="dayOfMonth">The day of the month</param>
+        public PeriodOnceSet LastWeekdayBefore(DayOfWeek dayOfWeek, int dayOfMonth)
+        {
+            _calculator.PeriodCalculations.Add(last => 
+            {
+                var next = new DateTime(last.Year, last.Month, dayOfMonth);
+                
+                while (next.DayOfWeek != dayOfWeek)
+                {
+                    next = next.AddDays(-1);
+                }
+
+                return next;
+            });
+
+            return new PeriodOnceSet(_calculator);
+        }
+
+        /// <summary>
+        /// Runs the job on the first given week of day after the given day of month.
+        /// </summary>
+        /// <param name="dayOfWeek">The day of the week</param>
+        /// <param name="dayOfMonth">The day of the month</param>
+        public PeriodOnceSet FirstWeekdayAfter(DayOfWeek dayOfWeek, int dayOfMonth)
+        {
+            _calculator.PeriodCalculations.Add(last => 
+            {
+                var next = new DateTime(last.Year, last.Month, dayOfMonth);
+                
+                while (next.DayOfWeek != dayOfWeek)
+                {
+                    next = next.AddDays(+1);
+                }
+
+                return next;
+            });
+
+            return new PeriodOnceSet(_calculator);
+        }
+
         private static DateTime SelectNthDay(int year, int month, DayOfWeek dayOfWeek, int occurrence) =>
             Enumerable.Range(1, 7)
                 .Select(day => new DateTime(year, month, day))


### PR DESCRIPTION
## LastWeekdayBefore and FirstWeekdayAfter

Added functionality to schedule a job on the last week day before a certain date. Or on the first week day after a certain date.

Issue #217 

If desired I can also implement this in the current version of the library. Just need to set up a Windows machine for that so I will raise a separate pull request for that one.

## Technical comments

Implemented by iterating through the date until the desired dayOfWeek has been found.

The current implementation does not account for the fact that the month can trip over to the previous or next month. This is something that can be implemented but I didn't feel the need because this also makes the behavior less transparent.

## Testing

To test this new feature I added corresponding unit tests. For completeness, I added them for both the new methods and the .At() postfix.
