### PR TITLE
Manage month week day unit

### DIFF
--- a/Library/Extension/DateTimeExtensions.cs
+++ b/Library/Extension/DateTimeExtensions.cs
@@ -75,9 +75,6 @@
 
         internal static DateTime NextNWeekday(this DateTime current, int toAdvance)
         {
-            while (!current.IsWeekday())
-                current = current.AddDays(1);
-
             while (toAdvance >= 1)
             {
                 toAdvance--;

--- a/Library/Extension/DateTimeExtensions.cs
+++ b/Library/Extension/DateTimeExtensions.cs
@@ -21,6 +21,14 @@
             return current.First().AddDays(daysInMonth - 1);
         }
 
+        internal static DateTime LastWeekDay(this DateTime current)
+        {
+            var lastDay = current.Last();
+            while (!lastDay.IsWeekday())
+                lastDay = lastDay.AddDays(-1);
+            return lastDay;
+        }
+
         internal static DateTime Last(this DateTime current, DayOfWeek dayOfWeek)
         {
             var last = current.Last();
@@ -52,8 +60,24 @@
             return current.AddDays(offsetDays);
         }
 
+        internal static DateTime PreviousNWeekday(this DateTime current, int toAdvance)
+        {
+            while (toAdvance <= -1)
+            {
+                toAdvance++;
+                current = current.AddDays(-1);
+
+                while (!current.IsWeekday())
+                    current = current.AddDays(-1);
+            }
+            return current;
+        }
+
         internal static DateTime NextNWeekday(this DateTime current, int toAdvance)
         {
+            while (!current.IsWeekday())
+                current = current.AddDays(1);
+
             while (toAdvance >= 1)
             {
                 toAdvance--;

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Unit\MinuteUnit.cs" />
     <Compile Include="Extension\RestrictableUnitExtensions.cs" />
     <Compile Include="Unit\MillisecondUnit.cs" />
+    <Compile Include="Unit\MonthOnLastWeekDayOfMonthUnit.cs" />
+    <Compile Include="Unit\MonthOnWeekDayOfMonthUnit.cs" />
     <Compile Include="Unit\SecondUnit.cs" />
     <Compile Include="Event\JobExceptionInfo.cs" />
     <Compile Include="Unit\DelayTimeUnit.cs" />

--- a/Library/Unit/MonthOnLastWeekDayOfMonthUnit.cs
+++ b/Library/Unit/MonthOnLastWeekDayOfMonthUnit.cs
@@ -1,0 +1,43 @@
+﻿namespace FluentScheduler
+{
+    using System;
+
+    /// <summary>
+    /// Unit of time that represents last day of the month.
+    /// </summary>
+    public sealed class MonthOnLastWeekDayOfMonthUnit
+    {
+        private readonly int _duration;
+
+        internal MonthOnLastWeekDayOfMonthUnit(Schedule schedule, int duration)
+        {
+            _duration = duration;
+            Schedule = schedule;
+            At(0, 0);
+        }
+
+        internal Schedule Schedule { get; private set; }
+
+        /// <summary>
+        /// Runs the job at the given time of day.
+        /// </summary>
+        /// <param name="hours">The hours (0 through 23).</param>
+        /// <param name="minutes">The minutes (0 through 59).</param>
+        public void At(int hours, int minutes)
+        {
+            Schedule.CalculateNextRun = x =>
+            {
+                Func<DateTime, DateTime> calculate = y =>
+                {
+                    return y.LastWeekDay().AddHours(hours).AddMinutes(minutes);
+                };
+
+                var date              = x.Date.First();
+                var runThisMonth      = calculate(date);
+                var runAfterThisMonth = calculate(date.AddMonths(_duration));
+
+                return x > runThisMonth ? runAfterThisMonth : runThisMonth;
+            };
+        }
+    }
+}

--- a/Library/Unit/MonthOnWeekDayOfMonthUnit.cs
+++ b/Library/Unit/MonthOnWeekDayOfMonthUnit.cs
@@ -32,10 +32,11 @@
             {
                 Func<DateTime, DateTime> calculate = y =>
                 {
-                    var lastWeekDayOfMonth = y.LastWeekDay();
                     var weekDay = this.weekDayOfMonth > 0
-                                      ? y.NextNWeekday(this.weekDayOfMonth - 1)
+                                      ? y.AddDays(-1).NextNWeekday(this.weekDayOfMonth)
                                       : y.PreviousNWeekday(this.weekDayOfMonth);
+
+                    var lastWeekDayOfMonth = y.LastWeekDay();
                     if (weekDay > lastWeekDayOfMonth)
                         weekDay = lastWeekDayOfMonth;
 

--- a/Library/Unit/MonthOnWeekDayOfMonthUnit.cs
+++ b/Library/Unit/MonthOnWeekDayOfMonthUnit.cs
@@ -1,0 +1,53 @@
+﻿namespace FluentScheduler
+{
+    using System;
+
+    /// <summary>
+    /// Unit of time that represents a specific week day of the month.
+    /// </summary>
+    public sealed class MonthOnWeekDayOfMonthUnit
+    {
+        private readonly int _duration;
+
+        private readonly int weekDayOfMonth;
+
+        internal MonthOnWeekDayOfMonthUnit(Schedule schedule, int duration, int weekDayOfMonth)
+        {
+            _duration = duration;
+            this.weekDayOfMonth = weekDayOfMonth;
+            Schedule = schedule;
+            At(0, 0);
+        }
+
+        internal Schedule Schedule { get; private set; }
+
+        /// <summary>
+        /// Runs the job at the given time of day.
+        /// </summary>
+        /// <param name="hours">The hours (0 through 23).</param>
+        /// <param name="minutes">The minutes (0 through 59).</param>
+        public void At(int hours, int minutes)
+        {
+            Schedule.CalculateNextRun = x =>
+            {
+                Func<DateTime, DateTime> calculate = y =>
+                {
+                    var lastWeekDayOfMonth = y.LastWeekDay();
+                    var weekDay = this.weekDayOfMonth > 0
+                                      ? y.NextNWeekday(this.weekDayOfMonth - 1)
+                                      : y.PreviousNWeekday(this.weekDayOfMonth);
+                    if (weekDay > lastWeekDayOfMonth)
+                        weekDay = lastWeekDayOfMonth;
+
+                    return weekDay.AddHours(hours).AddMinutes(minutes);
+                };
+
+                var date = x.Date.First();
+                var runThisMonth = calculate(date);
+                var runAfterThisMonth = calculate(date.AddMonths(_duration));
+
+                return x > runThisMonth ? runAfterThisMonth : runThisMonth;
+            };
+        }
+    }
+}

--- a/Library/Unit/MonthUnit.cs
+++ b/Library/Unit/MonthUnit.cs
@@ -28,11 +28,28 @@
         }
 
         /// <summary>
+        /// Runs the job on the given week day of the month.
+        /// </summary>
+        /// <param name="weekDay">The week day (1 through the number of week days in month).</param>
+        public MonthOnWeekDayOfMonthUnit OnWeekDay(int weekDay)
+        {
+            return new MonthOnWeekDayOfMonthUnit(Schedule, _duration, weekDay);
+        }
+
+        /// <summary>
         /// Runs the job on the last day of the month.
         /// </summary>
         public MonthOnLastDayOfMonthUnit OnTheLastDay()
         {
             return new MonthOnLastDayOfMonthUnit(Schedule, _duration);
+        }
+
+        /// <summary>
+        /// Runs the job on the last week day of the month.
+        /// </summary>
+        public MonthOnLastWeekDayOfMonthUnit OnTheLastWeekDay()
+        {
+            return new MonthOnLastWeekDayOfMonthUnit(Schedule, _duration);
         }
 
         /// <summary>

--- a/PortableLibrary/PortableLibrary.csproj
+++ b/PortableLibrary/PortableLibrary.csproj
@@ -91,6 +91,12 @@
     <Compile Include="..\Library\Unit\MonthOnLastDayOfMonthUnit.cs">
       <Link>Unit\MonthOnLastDayOfMonthUnit.cs</Link>
     </Compile>
+    <Compile Include="..\Library\Unit\MonthOnLastWeekDayOfMonthUnit.cs">
+      <Link>Unit\MonthOnLastWeekDayOfMonthUnit.cs</Link>
+    </Compile>
+    <Compile Include="..\Library\Unit\MonthOnWeekDayOfMonthUnit.cs">
+      <Link>Unit\MonthOnWeekDayOfMonthUnit.cs</Link>
+    </Compile>
     <Compile Include="..\Library\Unit\MonthUnit.cs">
       <Link>Unit\MonthUnit.cs</Link>
     </Compile>

--- a/UnitTests/ScheduleTests/MonthsOnTheLastWeekDayTests.cs
+++ b/UnitTests/ScheduleTests/MonthsOnTheLastWeekDayTests.cs
@@ -1,0 +1,105 @@
+namespace FluentScheduler.Tests.UnitTests.ScheduleTests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    [TestClass]
+    public class MonthsOnTheLastWeekDayTests
+    {
+        [TestMethod]
+        public void Should_Add_Specified_Months_To_Next_Run_Date_And_Select_Last_Day_In_That_Month()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 1);
+            var expected = new DateTime(2000, 1, 31);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Take_Last_Friday()
+        {
+            // Arrange
+            var input    = new DateTime(2000, 4, 1);
+            var expected = new DateTime(2000, 4, 28);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Default_To_00_00_If_At_Is_Not_Defined()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 1, 1, 23, 25);
+            var expected = new DateTime(2000, 1, 31);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay();
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Override_Existing_Minutes_And_Seconds_If_At_Method_Is_Called()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 1, 1, 23, 25);
+            var expected = new DateTime(2000, 1, 31, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay().At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Next_Date_If_Now_Is_After_At_Time()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 31, 3, 15, 0).AddMilliseconds(1);
+            var expected = new DateTime(2000, 3, 31, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay().At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Today_If_Now_Is_Before_At_Time()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 31, 1, 23, 25);
+            var expected = new DateTime(2000, 1, 31, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnTheLastWeekDay().At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/UnitTests/ScheduleTests/MonthsOnWeekDayTests.cs
+++ b/UnitTests/ScheduleTests/MonthsOnWeekDayTests.cs
@@ -23,6 +23,38 @@ namespace FluentScheduler.Tests.UnitTests.ScheduleTests
         }
 
         [TestMethod]
+        public void Should_Pick_First_WeekDay()
+        {
+            // Arrange
+            var input    = new DateTime(2000, 1, 1); // Saturday
+            var expected = new DateTime(2000, 1, 3); // Monday
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().OnWeekDay(1);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_First_Day_Having_0()
+        {
+            // Arrange
+            var input    = new DateTime(2000, 1, 1);
+            var expected = new DateTime(2000, 1, 1);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().OnWeekDay(0);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void Should_Default_To_00_00_If_At_Is_Not_Defined()
         {
             // Arrange

--- a/UnitTests/ScheduleTests/MonthsOnWeekDayTests.cs
+++ b/UnitTests/ScheduleTests/MonthsOnWeekDayTests.cs
@@ -1,0 +1,121 @@
+namespace FluentScheduler.Tests.UnitTests.ScheduleTests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    [TestClass]
+    public class MonthsOnWeekDayTests
+    {
+        [TestMethod]
+        public void Should_Add_Specified_Months_To_Next_Run_Date_And_Select_Specified_Day()
+        {
+            // Assert
+            var input = new DateTime(2000, 1, 7);
+            var expected = new DateTime(2000, 3, 6);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnWeekDay(4);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Default_To_00_00_If_At_Is_Not_Defined()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 3, 1, 23, 25);
+            var expected = new DateTime(2000, 3, 1);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnWeekDay(1);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Last_Day_If_Specified_Day_Does_Not_Exist_In_Month()
+        {
+            // Arrange
+            var input = new DateTime(2000, 4, 1, 1, 23, 25);
+            var expected = new DateTime(2000, 4, 28); // Friday
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(1).Months().OnWeekDay(31);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Override_Existing_Minutes_And_Seconds_If_At_Method_Is_Called()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 3, 5, 23, 25);
+            var expected = new DateTime(2000, 3, 1, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnWeekDay(1).At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Handle_Negative_Numbers()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 1, 1, 23, 25);
+            var expected = new DateTime(2000, 02, 29);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(2).Months().OnWeekDay(-1);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Next_Date_If_Now_Is_After_At_Time()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 3, 3, 15, 0).AddMilliseconds(1);
+            var expected = new DateTime(2000, 4, 3, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(3).Months().OnWeekDay(1).At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Should_Pick_Today_If_Now_Is_Before_At_Time()
+        {
+            // Arrange
+            var input = new DateTime(2000, 1, 3, 1, 23, 25);
+            var expected = new DateTime(2000, 1, 3, 3, 15, 0);
+
+            // Act
+            var schedule = new Schedule(() => { });
+            schedule.ToRunEvery(3).Months().OnWeekDay(1).At(3, 15);
+            var actual = schedule.CalculateNextRun(input);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -76,6 +76,8 @@
     <Compile Include="ScheduleTests\MinutesTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ScheduleTests\MonthsOnTheLastWeekDayTests.cs" />
+    <Compile Include="ScheduleTests\MonthsOnWeekDayTests.cs" />
     <Compile Include="ScheduleTests\MonthsOnTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Hi,

For ~specific~ several jobs, we need to configure as `n week day of month` or `last week day of month`.

To manage this, i added 2 methods in `MonthUnit`
- `Month.OnWeekDay(int n)`
- `Month.OnTheLastWeekDay()`

Thanks!