### PR TITLE
Get execution dates of Scheduler in the future

### DIFF
--- a/Library/Extension/ScheduleExtensions.cs
+++ b/Library/Extension/ScheduleExtensions.cs
@@ -2,7 +2,7 @@ namespace FluentScheduler
 {
     using System;
 
-    internal static class ScheduleExtensions
+    public static class ScheduleExtensions
     {
         public static DateTime? FindNextRun(this Schedule schedule, DateTime following)
         {

--- a/Library/Extension/ScheduleExtensions.cs
+++ b/Library/Extension/ScheduleExtensions.cs
@@ -12,7 +12,7 @@ namespace FluentScheduler
                 return null;
             }
 
-            var next = schedule.CalculateNextRun(following);
+            var next = schedule.CalculateNextRun(following.AddTicks(1));
 
             if (next > following)
             {

--- a/Library/Extension/ScheduleExtensions.cs
+++ b/Library/Extension/ScheduleExtensions.cs
@@ -1,6 +1,7 @@
 namespace FluentScheduler
 {
     using System;
+    using System.Linq;
 
     public static class ScheduleExtensions
     {

--- a/Library/Extension/ScheduleExtensions.cs
+++ b/Library/Extension/ScheduleExtensions.cs
@@ -1,0 +1,33 @@
+namespace FluentScheduler
+{
+    using System;
+
+    internal static class ScheduleExtensions
+    {
+        public static DateTime? FindNextRun(this Schedule schedule, DateTime following)
+        {
+            var next = schedule.CalculateNextRun(following);
+
+            if (next > following)
+            {
+                return next;
+            }
+            else
+            {
+                var subNext = schedule.AdditionalSchedules
+                                      .Select(x => x.FindNextRun(following))
+                                      .Where(x => x.HasValue)
+                                      .OrderBy(x => x.Value)
+                                      .Where(x => x.Value > following)
+                                      .ToArray();
+
+                if (subNext.Length > 0)
+                {
+                    return subNext.First();
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Library/Extension/ScheduleExtensions.cs
+++ b/Library/Extension/ScheduleExtensions.cs
@@ -7,6 +7,11 @@ namespace FluentScheduler
     {
         public static DateTime? FindNextRun(this Schedule schedule, DateTime following)
         {
+            if(schedule == null)
+            {
+                return null;
+            }
+
             var next = schedule.CalculateNextRun(following);
 
             if (next > following)

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extension\DelayForExtensions.cs" />
+    <Compile Include="Extension\ScheduleExtensions.cs" />
     <Compile Include="Unit\IDayRestrictableUnit.cs" />
     <Compile Include="Unit\ITimeRestrictableUnit.cs" />
     <Compile Include="Unit\MinuteUnit.cs" />

--- a/Library/Schedule.cs
+++ b/Library/Schedule.cs
@@ -27,7 +27,7 @@
 
         internal List<Action> Jobs { get; private set; }
 
-        internal Func<DateTime, DateTime> CalculateNextRun { get; set; }
+        public Func<DateTime, DateTime> CalculateNextRun { get; internal set; }
 
         internal TimeSpan DelayRunFor { get; set; }
 

--- a/Library/Schedule.cs
+++ b/Library/Schedule.cs
@@ -27,7 +27,7 @@
 
         internal List<Action> Jobs { get; private set; }
 
-        public Func<DateTime, DateTime> CalculateNextRun { get; internal set; }
+        internal Func<DateTime, DateTime> CalculateNextRun { get; set; }
 
         internal TimeSpan DelayRunFor { get; set; }
 


### PR DESCRIPTION
I would like to get some dates for a schedule without scheduling an action in the jobmanager, e.g.

```
var nextRun = new Schedule().ToRunOnceAt(...).AndEvery(...).CalculateNextRun(Tomorrow)
Console.WriteLine($"Your next schedule run from tomorrow will be at {nextRun}");
```