### PR TITLE
ScheduleGroup.NextRun() fix

### DIFF
--- a/FluentScheduler.UnitTests/Scheduler/ScheduleGroupTests.cs
+++ b/FluentScheduler.UnitTests/Scheduler/ScheduleGroupTests.cs
@@ -132,8 +132,6 @@ public class ScheduleGroupTests
         scheduleGroup.SetScheduling(newRun => newRun.Every(3).Minutes());
         scheduleGroup.Start();
 
-        scheduleGroup.StopAndBlock();
-
         // Assert
         Equal(now.AddMinutes(3).Minute, scheduleGroup[0].NextRun.Value.Minute);
     }
@@ -301,5 +299,12 @@ public class ScheduleGroupTests
         // Assert
         True(nextRun.HasValue);
         Equal(expectedNextRun.AddMinutes(10).Minute, nextRun.Value.Item2.Minute);
+
+        // Act
+        scheduleGroup.StopAndBlock();
+        nextRun = scheduleGroup.NextRun();
+
+        // Assert
+        False(nextRun.HasValue);
     }
 }

--- a/FluentScheduler.UnitTests/Scheduler/ScheduleGroupTests.cs
+++ b/FluentScheduler.UnitTests/Scheduler/ScheduleGroupTests.cs
@@ -285,6 +285,7 @@ public class ScheduleGroupTests
         // Arrange
         var scheduleGroup = new List<Schedule>
         {
+            new(() => { } , run => run.Now()),
             new(() => { } , run => run.Every(10).Minutes()),
             new(() => { } , run => run.Every(20).Minutes()),
         };
@@ -298,6 +299,7 @@ public class ScheduleGroupTests
         var nextRun = scheduleGroup.NextRun();
 
         // Assert
+        True(nextRun.HasValue);
         Equal(expectedNextRun.AddMinutes(10).Minute, nextRun.Value.Item2.Minute);
     }
 }

--- a/FluentScheduler.UnitTests/Scheduler/ScheduleTests.cs
+++ b/FluentScheduler.UnitTests/Scheduler/ScheduleTests.cs
@@ -21,6 +21,7 @@ public class ScheduleTests
         // Assert
         Equal(1, calls);
         True(schedule.Running);
+        True(schedule.NextRun.HasValue);
 
         // Act
         await Task.Delay(1000);
@@ -67,6 +68,7 @@ public class ScheduleTests
         // Assert
         Equal(1, calls);
         True(schedule.Running);
+        True(schedule.NextRun.HasValue);
 
         // Act
         await Task.Delay(1000);
@@ -107,6 +109,7 @@ public class ScheduleTests
 
         // Assert
         False(schedule.Running);
+        False(schedule.NextRun.HasValue);
     }
 
     [Fact]
@@ -130,6 +133,7 @@ public class ScheduleTests
         // Assert
         Equal(1, calls);
         False(schedule.Running);
+        False(schedule.NextRun.HasValue);
     }
 
     [Fact]

--- a/FluentScheduler/Scheduler/InternalSchedule.cs
+++ b/FluentScheduler/Scheduler/InternalSchedule.cs
@@ -107,6 +107,7 @@ internal class InternalSchedule
 
             _task = null;
             _tokenSource = null;
+            NextRun = null;
         }
     }
 

--- a/FluentScheduler/Scheduler/ScheduleGroup.cs
+++ b/FluentScheduler/Scheduler/ScheduleGroup.cs
@@ -22,7 +22,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ArgumentNullException.ThrowIfNull(handler);
 
-        ForEach(schedules, false, i => i.JobStarted += handler);
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.JobStarted += handler
+        );
     }
 
     /// <summary>
@@ -36,7 +40,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ArgumentNullException.ThrowIfNull(handler);
 
-        ForEach(schedules, false, i => i.JobEnded += handler);
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.JobEnded += handler
+        );
     }
 
     /// <summary>
@@ -50,7 +58,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ArgumentNullException.ThrowIfNull(handler);
 
-        ForEach(schedules, false, i => i.JobStarted -= handler);
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.JobStarted -= handler
+        );
     }
 
     /// <summary>
@@ -64,7 +76,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ArgumentNullException.ThrowIfNull(handler);
 
-        ForEach(schedules, false, i => i.JobEnded -= handler);
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.JobEnded -= handler
+        );
     }
 
 
@@ -76,7 +92,12 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        ForEach(schedules, false, i => i.ShouldNotBeRunning(), i => i.ResetScheduling());
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.ShouldNotBeRunning(),
+            i => i.ResetScheduling()
+        );
     }
 
     /// <summary>
@@ -90,7 +111,10 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(specifier);
 
         ForEach(
-            schedules, false, i => i.ShouldNotBeRunning(), i => i.SetScheduling(new FluentTimeCalculator(specifier))
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.ShouldNotBeRunning(),
+            i => i.SetScheduling(new FluentTimeCalculator(specifier))
         );
     }
 
@@ -102,7 +126,11 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        ForEach(schedules, false, i => i.Start());
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.Start()
+        );
     }
 
     /// <summary>
@@ -113,7 +141,11 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        ForEach(schedules, false, i => i.Stop(false));
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            false, // no need to parallelize the iterations
+            i => i.Stop(false)
+        );
     }
 
     /// <summary>
@@ -124,7 +156,11 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        ForEach(schedules, true, i => i.Stop(true));
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            true, // running the iterations in parallel
+            i => i.Stop(true)
+        );
     }
 
     /// <summary>
@@ -137,7 +173,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ArgumentOutOfRangeException.ThrowIfNegative(timeout);
 
-        ForEach(schedules, true, i => i.Stop(true, timeout));
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            true, // running the iterations in parallel
+            i => i.Stop(true, timeout)
+        );
     }
 
     /// <summary>
@@ -150,7 +190,11 @@ public static class ScheduleGroup
         ArgumentNullException.ThrowIfNull(schedules);
         ThrowHelper.ThrowIfNegative(timeout);
 
-        ForEach(schedules, true, i => i.Stop(true, timeout.Milliseconds));
+        ForEach(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            true, // running the iterations in parallel
+            i => i.Stop(true, timeout.Milliseconds)
+        );
     }
 
     /// <summary>
@@ -162,7 +206,10 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        return Select(schedules, i => i.Running()).All(r => r);
+        return Select(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            i => i.Running()
+        ).All(r => r);
     }
 
     /// <summary>
@@ -174,7 +221,10 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        return Select(schedules, i => i.Running()).All(r => !r);
+        return Select(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            i => i.Running()
+        ).All(r => !r);
     }
 
     /// <summary>
@@ -186,7 +236,10 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        return Select(schedules, i => i.Running()).Any(r => r);
+        return Select(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            i => i.Running()
+        ).Any(r => r);
     }
 
     /// <summary>
@@ -198,7 +251,10 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        return Select(schedules, i => i.Running()).Any(r => !r);
+        return Select(
+            [.. schedules], // forcing evaluation of a potential deferred execution
+            i => i.Running()
+        ).Any(r => !r);
     }
 
     /// <summary>
@@ -239,7 +295,7 @@ public static class ScheduleGroup
     // acquire all running locks, runs the given action on the given schedules (in parallel or not), then release the
     // acquired locks
     private static void ForEach(
-        IEnumerable<Schedule> schedules, bool parallel, params Action<InternalSchedule>[] toRun)
+        Schedule[] schedules, bool parallel, params Action<InternalSchedule>[] toRun)
     {
         var internals = Internal(schedules);
 
@@ -267,7 +323,7 @@ public static class ScheduleGroup
     }
 
     // acquires all running locks, runs LINQ's Select() on the given schedules, then release the acquired locks
-    private static IEnumerable<T> Select<T>(IEnumerable<Schedule> schedules, Func<InternalSchedule, T> selector)
+    private static T[] Select<T>(Schedule[] schedules, Func<InternalSchedule, T> selector)
     {
         var internals = Internal(schedules);
 
@@ -284,18 +340,18 @@ public static class ScheduleGroup
     }
 
     // a shorthand for getting the internal schedules behind the given schedules, purely for readability
-    private static InternalSchedule[] Internal(IEnumerable<Schedule> schedules) =>
+    private static InternalSchedule[] Internal(Schedule[] schedules) =>
         [.. schedules.Select(s => s.Internal)];
 
     // synchronously acquires all running locks of all schedules
-    private static void EnterLock(IEnumerable<InternalSchedule> internals)
+    private static void EnterLock(InternalSchedule[] internals)
     {
         foreach (var i in internals)
             Monitor.Enter(i.RunningLock);
     }
 
     // synchronously releases all the running locks of all schedules
-    private static void ExitLock(IEnumerable<InternalSchedule> internals)
+    private static void ExitLock(InternalSchedule[] internals)
     {
         foreach (var i in internals)
             Monitor.Exit(i.RunningLock);

--- a/FluentScheduler/Scheduler/ScheduleGroup.cs
+++ b/FluentScheduler/Scheduler/ScheduleGroup.cs
@@ -266,30 +266,23 @@ public static class ScheduleGroup
     {
         ArgumentNullException.ThrowIfNull(schedules);
 
-        // getting any potential deferred execution out of the way
-        var _schedules = schedules.ToArray();
+        var _schedules = schedules.ToArray(); // forcing evaluation of a potential deferred execution
+
+        var times = Select(_schedules, i => i.NextRun) // all next run times (including nulls for stopped schedules)
+            .Where(i => i.HasValue) // keeping only running schedules
+            .Select(i => i.Value) // filtering out the nulls
+            .ToArray();
 
         // nothing to do if the collection is empty
-        if (!_schedules.Any())
+        if (!times.Any())
             return null;
 
-        // the index of the earliest next run found and an array of schedules' next run times
-        var earliest = 0;
-        var times = Select(_schedules, i => i.NextRun).ToArray();
+        // finding the earliest next run time and schedule
+        var earliestTime = times.Min();
+        var i = Array.IndexOf(times, earliestTime);
+        var earliestSchedule = _schedules[i];
 
-        // finding the index of the earliest next run
-        for (var i = 0; i < times.Length; ++i)
-        {
-            if (times[i] < times[earliest])
-                earliest = i;
-        }
-
-        // if there's no next run we return null
-        if (!times[earliest].HasValue)
-            return null;
-
-        // a tuple of the schedule and next run time of the earliest found next run
-        return (_schedules[earliest], times[earliest].Value);
+        return (earliestSchedule, earliestTime);
     }
 
     // acquire all running locks, runs the given action on the given schedules (in parallel or not), then release the


### PR DESCRIPTION
There are two bug fixes in this PR:
- Setting `NextRun` to null when calling `Stop()` on a schedule (it was being left with value).
- On `ScheduleGroup.NextRun()`, filtering out schedules that are stopped before getting which one is the next (it was returning `null` by having only a single schedule stopped in the collection).

Also, it wasn't needed for the fix, but I took the oportunity to 'unlazy' (ToArray) the schedules of the ScheduleGroup as soon as possible (in the public method before passing to the private): 47c58b0